### PR TITLE
Excluding local chromium when packaging.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,3 +29,7 @@ layers:
   chrome:
     path: layer
 
+package:
+  exclude:
+    - node_modules/puppeteer/.local-chromium/**    
+


### PR DESCRIPTION
This way no need to use ```PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1```.
Normal `npm i` and `serverless invoke local -f` would work as well as live for AWS when using `headless_shell`.