### PR TITLE
Use puppeteer-core package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,11 @@ This project example returns a screenshot of page requested via `?address=` quer
 
 ### Usage
 
-It is very important to tell NPM to skip installing chromium from `puppeteer` package. To do so, installing dependencies should be done using this command:
+_Note_: this project uses `puppeteer-core` package rather than the standard `puppeteer` one. This is done in order to keep the function size in check - without this, your function size would be more than 200MB which is way too much. The difference between the two is [explained here](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteer-vs-puppeteer-core).
 
-```sh
-PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install
-```
+Install the project dependencies with `npm install` or `yarn`.
 
-or
-
-```sh
-PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 yarn
-```
-
-Without this, your function size would be more than 200MB which is way too much.
-
-After that, you can simply deploy your funciton.
+After that, you can simply deploy your function.
 
 ```sh
 sls deploy

--- a/handler.js
+++ b/handler.js
@@ -1,5 +1,5 @@
 'use strict';
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer-core');
 
 module.exports.index = async (event, context) => {
   try {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Recently AWS introduced [Layers](https://aws.amazon.com/about-aws/whats-new/2018/11/aws-lambda-now-supports-custom-runtimes-and-layers/) which enables sharing common code between functions and working with large dependencies (such as headless chrome) much easier.",
   "main": "handler.js",
   "dependencies": {
-    "puppeteer": "1.18.0",
+    "puppeteer-core": "1.18.0",
     "serverless-apigw-binary": "0.4.4",
     "serverless-apigwy-binary": "0.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,10 +216,10 @@ proxy-from-env@^1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
-puppeteer@1.18.0:
+puppeteer-core@1.18.0:
   version "1.18.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.18.0.tgz#227bccc52806db37b3ccf762a7d95c06163f296e"
-  integrity sha512-NCwSN4wEIj43k4jO8Asa5nzibrIDFHWykqkZFjkGr0/f6U73k1ysql0gadQmOGLtZewXvvWqlNo+4ZMgX+5vZA==
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-1.18.0.tgz#8bb948def94d1c47da13c563b7aa58ed93b74000"
+  integrity sha512-ufdJzdyXICTZ15w+PIMNWWHkURAnF9Gp4yEd7Vrl8QSsFUBMTCOmPtMWXBF3oSgSjcNoeLwVneFTtXmXSyV72g==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
Uses the `puppeteer-core` package over `puppeteer` to make the installation easier and less error prone.

With this change, there is no more need to use the shell variable flags on install and the install itself will run faster (no more downloading the bundled Chromium).

The difference between the packages can be found in the Puppeteer project docs here: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteer-vs-puppeteer-core